### PR TITLE
feat: add core UI components (#6)

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,0 +1,130 @@
+---
+/**
+ * Button — primary action component
+ * Supports link (href) or button element
+ */
+
+interface Props {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  href?: string;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  class?: string;
+}
+
+const {
+  variant = 'primary',
+  size = 'md',
+  href,
+  type = 'button',
+  disabled = false,
+  class: className = '',
+} = Astro.props;
+
+const Tag = href ? 'a' : 'button';
+---
+
+<Tag
+  class:list={['btn', `btn--${variant}`, `btn--${size}`, className]}
+  href={href}
+  type={!href ? type : undefined}
+  disabled={!href && disabled ? true : undefined}
+  aria-disabled={disabled ? 'true' : undefined}
+>
+  <slot />
+</Tag>
+
+<style>
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    font-family: var(--font-mono);
+    font-weight: var(--font-medium);
+    text-decoration: none;
+    border: none;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition:
+      transform var(--duration-fast) var(--ease-default),
+      box-shadow var(--duration-fast) var(--ease-default),
+      background-color var(--duration-fast) var(--ease-default),
+      color var(--duration-fast) var(--ease-default);
+  }
+
+  .btn:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+
+  .btn:disabled,
+  .btn[aria-disabled='true'] {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none !important;
+  }
+
+  /* Sizes */
+  .btn--sm {
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--text-sm);
+  }
+
+  .btn--md {
+    padding: var(--space-3) var(--space-6);
+    font-size: var(--text-base);
+  }
+
+  .btn--lg {
+    padding: var(--space-4) var(--space-8);
+    font-size: var(--text-lg);
+  }
+
+  /* Primary — cyan with glow */
+  .btn--primary {
+    background-color: var(--colour-cyan);
+    color: var(--colour-bg-primary);
+  }
+
+  .btn--primary:hover:not(:disabled):not([aria-disabled='true']) {
+    transform: translateY(-1px);
+    box-shadow: var(--glow-md);
+  }
+
+  .btn--primary:active:not(:disabled):not([aria-disabled='true']) {
+    transform: translateY(0);
+  }
+
+  /* Secondary — border with purple hover */
+  .btn--secondary {
+    background-color: transparent;
+    color: var(--colour-text-primary);
+    border: var(--border-medium) solid var(--colour-border);
+  }
+
+  .btn--secondary:hover:not(:disabled):not([aria-disabled='true']) {
+    border-color: var(--colour-purple);
+    color: var(--colour-purple);
+    transform: translateY(-1px);
+    box-shadow: 0 0 12px var(--colour-glow-purple);
+  }
+
+  .btn--secondary:active:not(:disabled):not([aria-disabled='true']) {
+    transform: translateY(0);
+  }
+
+  /* Ghost — text only */
+  .btn--ghost {
+    background-color: transparent;
+    color: var(--colour-link);
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .btn--ghost:hover:not(:disabled):not([aria-disabled='true']) {
+    color: var(--colour-link-hover);
+    text-decoration: underline;
+  }
+</style>

--- a/src/components/FeatureCard.astro
+++ b/src/components/FeatureCard.astro
@@ -1,0 +1,74 @@
+---
+/**
+ * FeatureCard — highlights a feature with icon, title, and description
+ */
+
+interface Props {
+  title: string;
+  description: string;
+  class?: string;
+}
+
+const { title, description, class: className = '' } = Astro.props;
+---
+
+<div class:list={['feature-card', className]}>
+  <div class="feature-card__icon">
+    <slot name="icon" />
+  </div>
+  <h3 class="feature-card__title">{title}</h3>
+  <p class="feature-card__description">{description}</p>
+</div>
+
+<style>
+  .feature-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-6);
+    background-color: var(--colour-bg-light);
+    border-radius: var(--radius-lg);
+    border: var(--border-thin) solid var(--colour-border);
+    transition:
+      transform var(--duration-fast) var(--ease-default),
+      box-shadow var(--duration-fast) var(--ease-default),
+      border-color var(--duration-fast) var(--ease-default);
+  }
+
+  .feature-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--colour-purple);
+  }
+
+  .feature-card__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    background-color: var(--colour-bg-lighter);
+    border-radius: var(--radius-md);
+    color: var(--colour-cyan);
+  }
+
+  .feature-card__icon :global(svg) {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
+  .feature-card__title {
+    font-family: var(--font-mono);
+    font-size: var(--text-lg);
+    font-weight: var(--font-semibold);
+    color: var(--colour-text-primary);
+    margin: 0;
+  }
+
+  .feature-card__description {
+    font-size: var(--text-sm);
+    color: var(--colour-text-secondary);
+    line-height: 1.6;
+    margin: 0;
+  }
+</style>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,0 +1,101 @@
+---
+/**
+ * Logo — Rackula rack mark
+ * Sharp-cornered rectangle with three horizontal slots (server rack abstraction)
+ */
+
+interface Props {
+  variant?: 'solid' | 'gradient';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  class?: string;
+}
+
+const { variant = 'solid', size = 'md', class: className = '' } = Astro.props;
+
+const sizes = {
+  sm: 24,
+  md: 32,
+  lg: 48,
+  xl: 64,
+};
+
+const pixelSize = sizes[size];
+---
+
+<svg
+  class:list={['logo', `logo--${variant}`, `logo--${size}`, className]}
+  width={pixelSize}
+  height={pixelSize}
+  viewBox="0 0 32 32"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label="Rackula logo"
+>
+  {variant === 'gradient' && (
+    <defs>
+      <linearGradient id="logo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="var(--colour-purple)" />
+        <stop offset="50%" stop-color="var(--colour-pink)" />
+        <stop offset="100%" stop-color="var(--colour-cyan)" />
+      </linearGradient>
+    </defs>
+  )}
+
+  <!-- Outer frame -->
+  <rect
+    x="2"
+    y="2"
+    width="28"
+    height="28"
+    rx="2"
+    stroke={variant === 'gradient' ? 'url(#logo-gradient)' : 'currentColor'}
+    stroke-width="2"
+    fill="none"
+  />
+
+  <!-- Slot 1 (top) -->
+  <rect
+    x="6"
+    y="7"
+    width="20"
+    height="4"
+    rx="1"
+    fill={variant === 'gradient' ? 'var(--colour-cyan)' : 'currentColor'}
+  />
+
+  <!-- Slot 2 (middle) -->
+  <rect
+    x="6"
+    y="14"
+    width="20"
+    height="4"
+    rx="1"
+    fill={variant === 'gradient' ? 'var(--colour-green)' : 'currentColor'}
+  />
+
+  <!-- Slot 3 (bottom) -->
+  <rect
+    x="6"
+    y="21"
+    width="20"
+    height="4"
+    rx="1"
+    fill={variant === 'gradient' ? 'var(--colour-pink)' : 'currentColor'}
+  />
+</svg>
+
+<style>
+  .logo {
+    display: inline-block;
+    flex-shrink: 0;
+  }
+
+  .logo--solid {
+    color: var(--colour-purple);
+  }
+
+  .logo--gradient {
+    /* Gradient applied via SVG defs */
+  }
+</style>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * SectionHeader — styled section heading with ## prefix
+ */
+
+interface Props {
+  class?: string;
+}
+
+const { class: className = '' } = Astro.props;
+---
+
+<h2 class:list={['section-header', className]}>
+  <span class="section-header__prefix">## </span><slot />
+</h2>
+
+<style>
+  .section-header {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xl);
+    font-weight: var(--font-semibold);
+    color: var(--colour-pink);
+    margin: 0 0 var(--space-6);
+  }
+
+  .section-header__prefix {
+    color: var(--colour-text-secondary);
+    user-select: none;
+  }
+
+  @media (min-width: 768px) {
+    .section-header {
+      font-size: var(--text-3xl);
+    }
+  }
+</style>

--- a/src/components/Terminal.astro
+++ b/src/components/Terminal.astro
@@ -1,0 +1,160 @@
+---
+/**
+ * Terminal — displays command examples with optional copy button
+ */
+
+interface Props {
+  command: string;
+  prompt?: string;
+  showCopy?: boolean;
+  class?: string;
+}
+
+const {
+  command,
+  prompt = '$',
+  showCopy = true,
+  class: className = '',
+} = Astro.props;
+---
+
+<div class:list={['terminal', className]}>
+  <div class="terminal__header">
+    <div class="terminal__dots">
+      <span class="terminal__dot terminal__dot--red"></span>
+      <span class="terminal__dot terminal__dot--yellow"></span>
+      <span class="terminal__dot terminal__dot--green"></span>
+    </div>
+    {showCopy && (
+      <button
+        class="terminal__copy"
+        type="button"
+        aria-label="Copy command"
+        data-command={command}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+      </button>
+    )}
+  </div>
+  <div class="terminal__body">
+    <code class="terminal__code">
+      <span class="terminal__prompt">{prompt}</span>
+      <span class="terminal__command">{command}</span>
+    </code>
+  </div>
+</div>
+
+<style>
+  .terminal {
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background-color: var(--colour-bg-darkest);
+    border: var(--border-thin) solid var(--colour-border);
+  }
+
+  .terminal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    background-color: var(--colour-bg-darker);
+    border-bottom: var(--border-thin) solid var(--colour-border);
+  }
+
+  .terminal__dots {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .terminal__dot {
+    width: 12px;
+    height: 12px;
+    border-radius: var(--radius-full);
+  }
+
+  .terminal__dot--red {
+    background-color: var(--colour-red);
+  }
+
+  .terminal__dot--yellow {
+    background-color: var(--colour-yellow);
+  }
+
+  .terminal__dot--green {
+    background-color: var(--colour-green);
+  }
+
+  .terminal__copy {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-1);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--colour-text-secondary);
+    cursor: pointer;
+    transition: color var(--duration-fast) var(--ease-default);
+  }
+
+  .terminal__copy:hover {
+    color: var(--colour-cyan);
+  }
+
+  .terminal__copy:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+
+  .terminal__body {
+    padding: var(--space-4);
+    overflow-x: auto;
+  }
+
+  .terminal__code {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    background: none;
+    padding: 0;
+  }
+
+  .terminal__prompt {
+    color: var(--colour-green);
+    margin-right: var(--space-2);
+    user-select: none;
+  }
+
+  .terminal__command {
+    color: var(--colour-text-primary);
+  }
+</style>
+
+<script>
+  document.querySelectorAll('.terminal__copy').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const command = button.getAttribute('data-command');
+      if (command) {
+        await navigator.clipboard.writeText(command);
+        // Brief visual feedback
+        button.style.color = 'var(--colour-green)';
+        setTimeout(() => {
+          button.style.color = '';
+        }, 1000);
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary

Create reusable component library following brand guide specifications:

- **Logo**: Rack mark with solid/gradient variants (sm/md/lg/xl sizes)
- **Button**: Primary (cyan glow), secondary (border), ghost variants
- **FeatureCard**: Icon + title + description with hover elevation
- **SectionHeader**: Pink monospace heading with `##` prefix styling
- **Terminal**: Command display with copy button and traffic light dots

## Files Changed

- `src/components/Logo.astro`: SVG rack mark with theme support
- `src/components/Button.astro`: Multi-variant button/link component
- `src/components/FeatureCard.astro`: Feature highlight card
- `src/components/SectionHeader.astro`: Styled section heading
- `src/components/Terminal.astro`: Command block with copy functionality

## Test Plan

- [ ] All components render in both dark and light themes
- [ ] Button hover/focus states work correctly
- [ ] Terminal copy button copies command to clipboard
- [ ] Build succeeds with no TypeScript errors

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)