### PR TITLE
chore: update logo mark to v2 (widow's peak) with heartbeat animation (#26)

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,19 +1,20 @@
 ---
 /**
  * Hero — landing section with animated logo and CTAs
+ * Uses v2 widow's peak mark with heartbeat animation timing
  */
 import Button from './Button.astro';
 ---
 
 <section class="hero">
   <div class="hero__content">
-    <!-- Animated gradient logo -->
+    <!-- Animated gradient logo (v2 widow's peak) -->
     <div class="hero__logo" aria-hidden="true">
       <svg
         class="hero__logo-svg"
-        width="128"
-        height="128"
-        viewBox="0 0 32 32"
+        width="72"
+        height="108"
+        viewBox="0 0 36 54"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         role="img"
@@ -27,23 +28,17 @@ import Button from './Button.astro';
           </linearGradient>
         </defs>
 
-        <!-- Outer frame -->
-        <rect
-          x="2"
-          y="2"
-          width="28"
-          height="28"
-          rx="2"
-          stroke="url(#hero-gradient)"
-          stroke-width="2"
-          fill="none"
+        <!-- Outer frame with widow's peak (v2) -->
+        <path
+          d="M0 0 L14 0 L18 6 L22 0 L36 0 L36 54 L0 54 Z"
+          fill="url(#hero-gradient)"
           class="hero__logo-frame"
         />
 
-        <!-- Slots with staggered animation -->
-        <rect x="6" y="7" width="20" height="4" rx="1" class="hero__logo-slot hero__logo-slot--1" />
-        <rect x="6" y="14" width="20" height="4" rx="1" class="hero__logo-slot hero__logo-slot--2" />
-        <rect x="6" y="21" width="20" height="4" rx="1" class="hero__logo-slot hero__logo-slot--3" />
+        <!-- Slots with heartbeat staggered animation -->
+        <rect x="5" y="10" width="26" height="10" class="hero__logo-slot hero__logo-slot--1" />
+        <rect x="5" y="22" width="26" height="10" class="hero__logo-slot hero__logo-slot--2" />
+        <rect x="5" y="34" width="26" height="10" class="hero__logo-slot hero__logo-slot--3" />
       </svg>
     </div>
 
@@ -98,26 +93,27 @@ import Button from './Button.astro';
   }
 
   .hero__logo-frame {
-    animation: frame-glow 4s ease-in-out infinite;
+    animation: frame-glow 2s ease-in-out infinite;
   }
 
   .hero__logo-slot {
-    animation: slot-pulse 4s ease-in-out infinite;
+    animation: slot-pulse 2s ease-in-out infinite;
   }
 
+  /* Heartbeat timing: 2s cycle, 0.15s stagger */
   .hero__logo-slot--1 {
-    fill: var(--colour-cyan);
+    fill: var(--colour-bg-primary);
     animation-delay: 0s;
   }
 
   .hero__logo-slot--2 {
-    fill: var(--colour-green);
-    animation-delay: 0.5s;
+    fill: var(--colour-bg-primary);
+    animation-delay: 0.15s;
   }
 
   .hero__logo-slot--3 {
-    fill: var(--colour-pink);
-    animation-delay: 1s;
+    fill: var(--colour-bg-primary);
+    animation-delay: 0.3s;
   }
 
   @keyframes frame-glow {
@@ -125,16 +121,56 @@ import Button from './Button.astro';
       filter: drop-shadow(0 0 4px var(--colour-glow-purple));
     }
     50% {
-      filter: drop-shadow(0 0 12px var(--colour-glow-purple));
+      filter: drop-shadow(0 0 16px var(--colour-glow-purple));
     }
   }
 
   @keyframes slot-pulse {
     0%, 100% {
-      opacity: 0.7;
+      fill: var(--colour-bg-primary);
     }
     50% {
-      opacity: 1;
+      fill: var(--colour-cyan);
+    }
+  }
+
+  /* Slot-specific colours during pulse */
+  .hero__logo-slot--1 {
+    animation-name: slot-pulse-cyan;
+  }
+
+  .hero__logo-slot--2 {
+    animation-name: slot-pulse-green;
+  }
+
+  .hero__logo-slot--3 {
+    animation-name: slot-pulse-pink;
+  }
+
+  @keyframes slot-pulse-cyan {
+    0%, 100% {
+      fill: var(--colour-bg-primary);
+    }
+    50% {
+      fill: var(--colour-cyan);
+    }
+  }
+
+  @keyframes slot-pulse-green {
+    0%, 100% {
+      fill: var(--colour-bg-primary);
+    }
+    50% {
+      fill: var(--colour-green);
+    }
+  }
+
+  @keyframes slot-pulse-pink {
+    0%, 100% {
+      fill: var(--colour-bg-primary);
+    }
+    50% {
+      fill: var(--colour-pink);
     }
   }
 
@@ -145,10 +181,16 @@ import Button from './Button.astro';
       animation: none;
     }
 
-    .hero__logo-slot--1,
-    .hero__logo-slot--2,
+    .hero__logo-slot--1 {
+      fill: var(--colour-cyan);
+    }
+
+    .hero__logo-slot--2 {
+      fill: var(--colour-green);
+    }
+
     .hero__logo-slot--3 {
-      opacity: 1;
+      fill: var(--colour-pink);
     }
   }
 
@@ -190,11 +232,21 @@ import Button from './Button.astro';
       justify-content: center;
       max-width: none;
     }
+
+    .hero__logo-svg {
+      width: 96px;
+      height: 144px;
+    }
   }
 
   @media (min-width: 1024px) {
     .hero {
       padding: var(--space-16) var(--space-8);
+    }
+
+    .hero__logo-svg {
+      width: 108px;
+      height: 162px;
     }
   }
 </style>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,32 +1,34 @@
 ---
 /**
- * Logo — Rackula rack mark
- * Sharp-cornered rectangle with three horizontal slots (server rack abstraction)
+ * Logo — Rackula rack mark (v2 widow's peak)
+ * Sharp-cornered frame with V-notch at top and three horizontal slots
  */
 
 interface Props {
   variant?: 'solid' | 'gradient';
-  size?: 'sm' | 'md' | 'lg' | 'xl';
+  size?: 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
   class?: string;
 }
 
 const { variant = 'solid', size = 'md', class: className = '' } = Astro.props;
 
+// Sizes maintain 36:54 aspect ratio (2:3)
 const sizes = {
-  sm: 24,
-  md: 32,
-  lg: 48,
-  xl: 64,
+  sm: { width: 16, height: 24 },
+  md: { width: 24, height: 36 },
+  lg: { width: 32, height: 48 },
+  xl: { width: 48, height: 72 },
+  xxl: { width: 64, height: 96 },
 };
 
-const pixelSize = sizes[size];
+const { width, height } = sizes[size];
 ---
 
 <svg
   class:list={['logo', `logo--${variant}`, `logo--${size}`, className]}
-  width={pixelSize}
-  height={pixelSize}
-  viewBox="0 0 32 32"
+  width={width}
+  height={height}
+  viewBox="0 0 36 54"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
   role="img"
@@ -42,46 +44,37 @@ const pixelSize = sizes[size];
     </defs>
   )}
 
-  <!-- Outer frame -->
-  <rect
-    x="2"
-    y="2"
-    width="28"
-    height="28"
-    rx="2"
-    stroke={variant === 'gradient' ? 'url(#logo-gradient)' : 'currentColor'}
-    stroke-width="2"
-    fill="none"
+  <!-- Outer frame with widow's peak (v2) -->
+  <path
+    d="M0 0 L14 0 L18 6 L22 0 L36 0 L36 54 L0 54 Z"
+    fill={variant === 'gradient' ? 'url(#logo-gradient)' : 'currentColor'}
   />
 
-  <!-- Slot 1 (top) -->
+  <!-- Slot 1 (top) — negative space -->
   <rect
-    x="6"
-    y="7"
-    width="20"
-    height="4"
-    rx="1"
-    fill={variant === 'gradient' ? 'var(--colour-cyan)' : 'currentColor'}
+    x="5"
+    y="10"
+    width="26"
+    height="10"
+    fill={variant === 'gradient' ? 'var(--colour-cyan)' : 'var(--colour-bg-primary)'}
   />
 
-  <!-- Slot 2 (middle) -->
+  <!-- Slot 2 (middle) — negative space -->
   <rect
-    x="6"
-    y="14"
-    width="20"
-    height="4"
-    rx="1"
-    fill={variant === 'gradient' ? 'var(--colour-green)' : 'currentColor'}
+    x="5"
+    y="22"
+    width="26"
+    height="10"
+    fill={variant === 'gradient' ? 'var(--colour-green)' : 'var(--colour-bg-primary)'}
   />
 
-  <!-- Slot 3 (bottom) -->
+  <!-- Slot 3 (bottom) — negative space -->
   <rect
-    x="6"
-    y="21"
-    width="20"
-    height="4"
-    rx="1"
-    fill={variant === 'gradient' ? 'var(--colour-pink)' : 'currentColor'}
+    x="5"
+    y="34"
+    width="26"
+    height="10"
+    fill={variant === 'gradient' ? 'var(--colour-pink)' : 'var(--colour-bg-primary)'}
   />
 </svg>
 


### PR DESCRIPTION
## Summary

Align logo mark with brand guide v2 specifications:

- **Widow's peak**: Replace rectangular frame with V-notch path at top
- **Aspect ratio**: Change viewBox from 32×32 to 36×54 (taller)
- **Animation timing**: 4s/0.5s → 2s/0.15s (heartbeat feel)
- **Sharp corners**: Remove `rx` radius (Geismar style)
- **Slot animation**: Colour pulse (cyan/green/pink) instead of opacity

## Files Changed

- `src/components/Logo.astro`: New widow's peak path, xxl size, 36:54 aspect
- `src/components/Hero.astro`: Updated logo SVG, heartbeat animation timing

## Test Plan

- [ ] `npm run build` succeeds
- [ ] Logo renders correctly at all sizes (sm/md/lg/xl/xxl)
- [ ] Animation timing feels "heartbeat-like" (2s cycle, 0.15s stagger)
- [ ] Both dark and light themes display correct colours
- [ ] `prefers-reduced-motion` still disables animations

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added xxl size option for logo component.

* **Style**
  * Updated logo design with new widow's peak variant.
  * Implemented heartbeat-based animation sequencing for logo slots.
  * Revised animation timing and colour-based pulsing effects.
  * Enhanced responsive logo scaling across multiple breakpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->