### PR TITLE
fix(hero): restore wordmark and reduce tagline prominence

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -42,10 +42,13 @@ import Button from './Button.astro';
       </svg>
     </div>
 
+    <!-- Brand name -->
+    <h1 class="hero__title">Rackula</h1>
+
     <!-- Tagline -->
-    <h1 class="hero__tagline">
+    <p class="hero__tagline">
       Plan your homelab rack layout.
-    </h1>
+    </p>
 
     <!-- Subtext -->
     <p class="hero__subtext">
@@ -195,12 +198,21 @@ import Button from './Button.astro';
   }
 
   /* Typography */
+  .hero__title {
+    font-family: var(--font-display);
+    font-size: var(--text-4xl);
+    font-weight: 500;
+    color: var(--colour-text-primary);
+    line-height: 1;
+    margin: 0;
+  }
+
   .hero__tagline {
     font-family: var(--font-mono);
-    font-size: var(--text-3xl);
-    font-weight: var(--font-semibold);
-    color: var(--colour-text-primary);
-    line-height: 1.2;
+    font-size: var(--text-xl);
+    font-weight: var(--font-normal);
+    color: var(--colour-text-secondary);
+    line-height: 1.4;
     margin: 0;
   }
 
@@ -224,7 +236,7 @@ import Button from './Button.astro';
   /* Desktop styles */
   @media (min-width: 640px) {
     .hero__tagline {
-      font-size: var(--text-4xl);
+      font-size: var(--text-2xl);
     }
 
     .hero__ctas {


### PR DESCRIPTION
## Summary

- Restores the "Rackula" wordmark as the primary h1 title with Space Grotesk display font
- Demotes the tagline to a p element with reduced visual prominence
- Fixes typography hierarchy so the brand name is prominent and tagline is supportive

## Changes

- **Wordmark**: Added `h1.hero__title` with Space Grotesk, text-4xl, primary colour
- **Tagline**: Changed from h1 to p element, reduced to text-xl (mobile) / text-2xl (desktop), secondary colour

## Test plan

- [ ] Wordmark "Rackula" displays prominently at top
- [ ] Tagline appears smaller and lighter beneath wordmark
- [ ] Typography hierarchy looks correct on mobile
- [ ] Typography hierarchy looks correct on desktop (640px+)
- [ ] Works in both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)