### PR TITLE
fix(footer): ensure logo stays purple in lockup

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -101,6 +101,11 @@ const links = [
     color: var(--colour-purple);
   }
 
+  /* Keep logo purple regardless of link state */
+  .footer__logo-link :global(.logo) {
+    color: var(--colour-purple);
+  }
+
   .footer__wordmark {
     font-family: var(--font-display);
     font-size: var(--text-lg);


### PR DESCRIPTION
## Summary

Fix the footer logo to stay Dracula purple instead of inheriting the link's text colour.

## Problem

The Logo component uses `currentColor` for the solid variant, which was inheriting from the footer link's `color: var(--colour-text-primary)` instead of the intended purple.

## Solution

Added a `:global(.logo)` rule inside the footer to explicitly set the logo colour to purple.

## Test Plan

- [ ] Logo is purple in footer (not white/text colour)
- [ ] Logo stays purple on hover
- [ ] Works in both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed footer logo colour to remain consistently purple across all link interaction states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->