### PR TITLE
fix: remove redundant theme toggle from footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,10 +1,9 @@
 ---
 /**
- * Footer — site navigation, branding, and theme toggle
+ * Footer — site navigation and branding
  * Minimal design matching brand aesthetic
  */
 import Logo from './Logo.astro';
-import ThemeToggle from './ThemeToggle.astro';
 
 const currentYear = new Date().getFullYear();
 
@@ -43,11 +42,6 @@ const links = [
           ))}
         </ul>
       </nav>
-
-      <!-- Theme toggle -->
-      <div class="footer__actions">
-        <ThemeToggle />
-      </div>
     </div>
 
     <div class="footer__bottom">
@@ -136,12 +130,6 @@ const links = [
 
   .footer__link:hover {
     color: var(--colour-cyan);
-  }
-
-  /* Actions */
-  .footer__actions {
-    display: flex;
-    align-items: center;
   }
 
   /* Bottom section */


### PR DESCRIPTION
## Summary

- Remove ThemeToggle component from Footer
- Remove unused `.footer__actions` CSS
- Update component docstring to reflect change

The sticky header already provides persistent access to theme switching, making the footer toggle redundant. This reduces visual clutter and simplifies maintenance.

## Files Changed

- `src/components/Footer.astro` — removed ThemeToggle import, markup, and styles

## Test Plan

- [x] Build passes
- [ ] Theme toggle works correctly from header
- [ ] Footer layout adjusts cleanly

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Removed theme toggle functionality from the footer. Navigation and branding elements remain fully functional and unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->