### PR TITLE
fix: remove redundant Rackula title from Hero section

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -42,11 +42,11 @@ import Button from './Button.astro';
       </svg>
     </div>
 
-    <!-- Brand name -->
-    <h1 class="hero__title">Rackula</h1>
+    <!-- Visually hidden brand name for SEO/accessibility -->
+    <h1 class="sr-only">Rackula</h1>
 
-    <!-- Tagline -->
-    <p class="hero__tagline">
+    <!-- Tagline as primary visible heading -->
+    <p class="hero__tagline" role="doc-subtitle">
       Plan your homelab rack layout.
     </p>
 
@@ -197,22 +197,26 @@ import Button from './Button.astro';
     }
   }
 
-  /* Typography */
-  .hero__title {
-    font-family: var(--font-display);
-    font-size: var(--text-4xl);
-    font-weight: 500;
-    color: var(--colour-text-primary);
-    line-height: 1;
-    margin: 0;
+  /* Screen reader only */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
+  /* Typography */
   .hero__tagline {
-    font-family: var(--font-mono);
-    font-size: var(--text-xl);
-    font-weight: var(--font-normal);
-    color: var(--colour-text-secondary);
-    line-height: 1.4;
+    font-family: var(--font-display);
+    font-size: var(--text-3xl);
+    font-weight: 500;
+    color: var(--colour-text-primary);
+    line-height: 1.2;
     margin: 0;
   }
 
@@ -236,7 +240,7 @@ import Button from './Button.astro';
   /* Desktop styles */
   @media (min-width: 640px) {
     .hero__tagline {
-      font-size: var(--text-2xl);
+      font-size: var(--text-4xl);
     }
 
     .hero__ctas {


### PR DESCRIPTION
## Summary

- Remove visible "Rackula" h1 (redundant with header wordmark)
- Add visually hidden h1 for SEO/accessibility
- Promote tagline as primary visible text with display font styling
- Increase tagline size (text-3xl mobile, text-4xl desktop)

The header already establishes brand identity. The hero now leads with the value proposition: "Plan your homelab rack layout."

## Files Changed

- `src/components/Hero.astro` — restructured text hierarchy

## Test Plan

- [x] Build passes
- [ ] "Rackula" only appears once above fold (in header)
- [ ] Tagline is visually prominent
- [ ] Screen readers still announce "Rackula" as h1

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Brand name is no longer visually displayed.
  * Tagline font size increased on desktop viewports.
  * Tagline presentation updated with subtitle formatting.

* **New Features**
  * Added screen-reader accessibility utility for hidden content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->