### PR TITLE
fix: remove connector lines from HowItWorks section

### DIFF
--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -45,7 +45,7 @@ const steps: Step[] = [
     <SectionHeader>how it works</SectionHeader>
 
     <div class="how-it-works__steps">
-      {steps.map((step, index) => (
+      {steps.map((step) => (
         <div class="step">
           <div class="step__icon-wrapper">
             {step.icon === 'plus' && (
@@ -81,9 +81,6 @@ const steps: Step[] = [
           </div>
           <h3 class="step__title">{step.title}</h3>
           <p class="step__description">{step.description}</p>
-          {index < steps.length - 1 && (
-            <div class="step__connector" aria-hidden="true"></div>
-          )}
         </div>
       ))}
     </div>
@@ -108,7 +105,6 @@ const steps: Step[] = [
   }
 
   .step {
-    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -174,11 +170,6 @@ const steps: Step[] = [
     max-width: 200px;
   }
 
-  /* Vertical connector for mobile */
-  .step__connector {
-    display: none;
-  }
-
   /* Desktop: horizontal layout */
   @media (min-width: 768px) {
     .how-it-works {
@@ -195,27 +186,6 @@ const steps: Step[] = [
       flex: 1;
       max-width: 200px;
       padding: var(--space-4) var(--space-6);
-    }
-
-    /* Horizontal connector line */
-    .step__connector {
-      display: block;
-      position: absolute;
-      top: 32px;
-      right: -50%;
-      width: 100%;
-      height: 2px;
-      background: linear-gradient(
-        90deg,
-        var(--colour-purple) 0%,
-        var(--colour-cyan) 100%
-      );
-      opacity: 0.3;
-      z-index: 0;
-    }
-
-    .step__icon-wrapper {
-      z-index: 1;
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove connector line divs from step markup
- Remove all connector-related CSS (mobile hidden, desktop gradient lines)
- Remove unused `position: relative` from `.step`
- Remove unused `index` variable from map function

The numbered badges (1, 2, 3, 4) and horizontal layout already communicate sequence clearly. The connector lines were visual noise competing with the actual content.

> "The grid and the numbers do the work. Lines would be noise."

## Files Changed

- `src/components/HowItWorks.astro` — removed 31 lines of connector code

## Test Plan

- [x] Build passes
- [ ] Steps display without connector lines
- [ ] Numbered badges remain prominent
- [ ] Section reads clearly as a sequence

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)