### PR TITLE
feat: conditionally show header CTA only when Hero scrolls out of view

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,8 @@
 ---
 /**
  * Header — sticky navigation with logo, links, and theme toggle
- * Features backdrop blur on scroll and mobile hamburger menu
+ * Features backdrop blur on scroll, mobile hamburger menu,
+ * and CTA that appears only after Hero scrolls out of view
  */
 import Logo from './Logo.astro';
 import ThemeToggle from './ThemeToggle.astro';
@@ -121,6 +122,27 @@ const ctaLink = { label: 'Open App', href: 'https://count.racku.la' };
 
   window.addEventListener('scroll', updateHeaderState, { passive: true });
   updateHeaderState();
+
+  // Hero visibility detection — show CTA only when Hero is out of view
+  const hero = document.querySelector('.hero');
+
+  if (hero) {
+    const heroObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          // When Hero is NOT intersecting (scrolled out of view), show header CTA
+          header?.classList.toggle('header--hero-hidden', !entry.isIntersecting);
+        });
+      },
+      {
+        // Trigger when Hero bottom edge crosses viewport top
+        rootMargin: '0px 0px 0px 0px',
+        threshold: 0
+      }
+    );
+
+    heroObserver.observe(hero);
+  }
 
   // Mobile menu toggle
   function toggleMenu() {
@@ -275,8 +297,20 @@ const ctaLink = { label: 'Open App', href: 'https://count.racku.la' };
     background-color: var(--colour-cyan);
     border-radius: var(--radius-md);
     text-decoration: none;
-    transition: transform var(--duration-fast) var(--ease-default),
+    /* Hidden by default — shown when Hero scrolls out of view */
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: opacity var(--duration-normal) var(--ease-default),
+                transform var(--duration-normal) var(--ease-default),
                 box-shadow var(--duration-fast) var(--ease-default);
+  }
+
+  /* Show CTA when Hero is no longer visible */
+  .header--hero-hidden .header__cta {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
   }
 
   .header__cta:hover {


### PR DESCRIPTION
## Summary

- Hide header "Open App" CTA while Hero "Start Planning" button is visible
- Show header CTA with fade-in animation when Hero scrolls out of view
- Uses Intersection Observer for efficient scroll detection (no scroll event spam)

This eliminates redundant competing CTAs above the fold while preserving persistent CTA access after scrolling.

## Implementation Details

- **Intersection Observer** watches `.hero` section
- **`header--hero-hidden`** class added when Hero exits viewport
- **CSS transition** fades CTA in with opacity + subtle translateY animation

## Files Changed

- `src/components/Header.astro` — added Hero observer and conditional CTA styles

## Test Plan

- [x] Build passes
- [ ] CTA hidden on page load (Hero visible)
- [ ] CTA appears with fade when scrolling past Hero
- [ ] CTA remains visible when scrolling further down
- [ ] Works on mobile viewport

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Header call-to-action button now intelligently responds to Hero section visibility. The button automatically hides when the Hero is in view and appears when you scroll past it, improving navigation accessibility and visual hierarchy on the page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->