### PR TITLE
fix: Hero logo solid purple with black slots by default

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -8,7 +8,7 @@ import Button from './Button.astro';
 
 <section class="hero">
   <div class="hero__content">
-    <!-- Gradient logo (v2 widow's peak) — animates on hover -->
+    <!-- Logo mark (v2 widow's peak) — solid purple, animates on hover -->
     <div class="hero__logo" aria-hidden="true" tabindex="0">
       <svg
         class="hero__logo-svg"
@@ -20,18 +20,10 @@ import Button from './Button.astro';
         role="img"
         aria-label="Rackula logo"
       >
-        <defs>
-          <linearGradient id="hero-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="var(--colour-purple)" />
-            <stop offset="50%" stop-color="var(--colour-pink)" />
-            <stop offset="100%" stop-color="var(--colour-cyan)" />
-          </linearGradient>
-        </defs>
-
-        <!-- Outer frame with widow's peak (v2) -->
+        <!-- Outer frame with widow's peak (v2) — solid brand purple -->
         <path
           d="M0 0 L14 0 L18 6 L22 0 L36 0 L36 54 L0 54 Z"
-          fill="url(#hero-gradient)"
+          fill="var(--colour-purple)"
           class="hero__logo-frame"
         />
 
@@ -103,19 +95,11 @@ import Button from './Button.astro';
     transition: filter var(--duration-normal) var(--ease-default);
   }
 
-  /* Static slot colours by default */
-  .hero__logo-slot--1 {
-    fill: var(--colour-cyan);
-    transition: fill var(--duration-normal) var(--ease-default);
-  }
-
-  .hero__logo-slot--2 {
-    fill: var(--colour-green);
-    transition: fill var(--duration-normal) var(--ease-default);
-  }
-
+  /* Slots are background colour by default — colours reveal on hover */
+  .hero__logo-slot--1,
+  .hero__logo-slot--2,
   .hero__logo-slot--3 {
-    fill: var(--colour-pink);
+    fill: var(--colour-bg-primary);
     transition: fill var(--duration-normal) var(--ease-default);
   }
 


### PR DESCRIPTION
## Summary

- Frame changed from gradient (`purple→pink→cyan`) to solid `--colour-purple`
- Slots changed from coloured (cyan, green, pink) to `--colour-bg-primary` (black)
- Colours now reveal only on hover/focus via the existing heartbeat animation
- Removed unused gradient `<defs>` from SVG

## Design Rationale

Geismar approach: solid geometry, no tricks. A strong mark uses consistent, recognisable colour. The gradient created visual noise and diluted brand recognition.

## Test Plan

- [ ] Visual check: logo is solid purple with black slots at rest
- [ ] Hover interaction: slots pulse with cyan, green, pink
- [ ] Light mode: uses Alucard purple automatically
- [ ] Build succeeds

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the hero section logo design with a solid purple frame and refined colour interactions. Slots now display a unified default appearance with colours revealed on hover. Hover and focus animations remain active for enhanced visual feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->