### PR TITLE
fix(ci): bump deploy workflow to Node 22 for Astro 7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
The launch merge (#56) deploy failed at the build step:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

`deploy.yml` pinned Node 20; Astro 7 needs ≥22.12. The `npm audit` gate passed (it runs on 20), but `astro build` refuses to run. Bump `setup-node` to Node 22.

Nothing deployed on the failed run, so this is the fix that lets the cutover complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)