### PR TITLE
fix(deploy): pin wrangler v4 so _headers/_redirects apply; drop unmanageable routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Wrangler 4 consumes _headers/_redirects as config for static assets.
+          # Wrangler 3 uploaded them as servable files, so headers never applied.
+          wranglerVersion: '4.106.0'
           command: deploy

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,14 +1,9 @@
 name = "rackula-www"
 compatibility_date = "2026-06-26"
 
-# Bind both hostnames to this Worker so the domain serves the site on deploy.
-# Apex is bound too — public/_redirects only fires its racku.la → www 301 if the
-# apex request actually reaches the Worker. Requires the deploy token to have
-# Workers Routes + DNS edit on the racku.la zone.
-routes = [
-  { pattern = "www.racku.la", custom_domain = true },
-  { pattern = "racku.la", custom_domain = true },
-]
+# Custom domains (www.racku.la + apex racku.la) are bound to this Worker as
+# Cloudflare Custom Domains, managed in the dashboard — not declared here. The
+# deploy token only needs Workers Scripts edit; it does not manage routes/DNS.
 
 [assets]
 directory = "./dist"


### PR DESCRIPTION
First live deploy (post-launch) surfaced two issues:

**1. Security headers not applied.** `wrangler-action` defaulted to wrangler **3.90**, which uploads `public/_headers` and `public/_redirects` as *servable files* rather than consuming them as config. Result: no CSP/HSTS/X-Frame-Options live, and `/_headers` was publicly readable (HTTP 200). Pin `wranglerVersion: '4.106.0'` — v4 consumes both as static-asset config.

**2. Deploy errored on custom_domain routes.** `POST /zones/.../workers/routes` → Cloudflare API `10000` auth error; the scoped token can't manage Workers Routes/DNS. The `www` + apex Custom Domains are already bound to the Worker (from the earlier dashboard/Workers-Builds onboarding), so the routes block is dropped from `wrangler.toml`. The token now only needs Workers Scripts edit.

The Worker + assets already deploy fine (site is live); this makes the run green and the headers actually take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)