### PR TITLE
fix(deploy): drop invalid _redirects (apex→www lives at zone level)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,0 @@
-# Apex → www canonicalisation (www.racku.la is the canonical host)
-https://racku.la/* https://www.racku.la/:splat 301
-
-# (Legacy www/apex → count.racku.la 301 is removed on the Cloudflare side,
-#  not here — it was a DNS/proxy-level redirect rule, not a _redirects entry.)


### PR DESCRIPTION
wrangler 4 rejects our `_redirects` (`Invalid _redirects configuration`): its only rule is a cross-host apex→www redirect, but static-asset `_redirects` match on path, not hostname. That canonicalisation is already a zone-level redirect rule (`racku.la` 301s to `www` independently of this file), so it's invalid *and* redundant here. Removing it lets the deploy succeed and `_headers` (CSP/HSTS/etc.) take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)