### PR TITLE
fix(ci): scope deploy GITHUB_TOKEN to contents:read (CodeQL)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN: this workflow only checks out the repo; the
+# Cloudflare deploy authenticates with CLOUDFLARE_API_TOKEN, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CodeQL (code-scanning alert #2) flagged `deploy.yml` for not limiting `GITHUB_TOKEN` permissions. The job only checks out the repo and deploys via `CLOUDFLARE_API_TOKEN` (not `GITHUB_TOKEN`), so a top-level `permissions: contents: read` is the minimal grant. Least privilege, no functional change.

Raised via the CodeQL comment on the now-superseded #55; addressing it on the live workflow here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)